### PR TITLE
Make things a bit better

### DIFF
--- a/libavcodec/vp8.h
+++ b/libavcodec/vp8.h
@@ -305,6 +305,13 @@ typedef struct VP8Context {
     uint8_t feature_present_prob[4];
     uint8_t feature_index_prob[4][3];
     uint8_t feature_value[4][4];
+
+    /**
+     * Still range decoder values preserved after header decoding
+     */
+    int rac_high;
+    int rac_bits;
+    unsigned int rac_code_word;
 } VP8Context;
 
 int ff_vp8_decode_init(AVCodecContext *avctx);


### PR DESCRIPTION
1) Don't segfault when reference frames don't exist (eg: First frame...)

2) Don't skip a bunch of important state management steps when decoding
frames

3) Make an initial attempt at tracking the coder values. It's mostly
correct, except there are some occasions when gst reports a frame
where the 'range' and 'value' are left-shifted by 1 and the count is
1 less relative to the ffmpeg values.
